### PR TITLE
Semigroup is a superclass of Monoid since base-4.11.0.0

### DIFF
--- a/Data/Foldable/Constrained.hs
+++ b/Data/Foldable/Constrained.hs
@@ -76,18 +76,25 @@ fold :: (Foldable t k k, Monoid m, Object k m, Object k (t m)) => t m `k` m
 fold = foldMap id
 
 newtype Endo' k a = Endo' { runEndo' :: k a a }
+instance (Category k, Object k a) => Semigroup (Endo' k a) where
+  (Endo' f) <> (Endo' g) = Endo' $ f . g
 instance (Category k, Object k a) => Monoid (Endo' k a) where
   mempty = Endo' id
-  mappend (Endo' f) (Endo' g) = Endo' $ f . g
+  mappend = (<>)
 
 newtype Monoidal_ (r :: * -> * -> *) (s :: * -> * -> *) (f :: * -> *) (u :: *) 
       = Monoidal { runMonoidal :: f u }
 instance ( Monoidal f k k, Function k
          , u ~ UnitObject k, Monoid u 
          , ObjectPair k u u, ObjectPair k (f u) (f u), Object k (f u,f u)
+         ) => Semigroup (Monoidal_ k k f u) where
+  (<>) = mappendMdl
+instance ( Monoidal f k k, Function k
+         , u ~ UnitObject k, Monoid u 
+         , ObjectPair k u u, ObjectPair k (f u) (f u), Object k (f u,f u)
          ) => Monoid (Monoidal_ k k f u) where
   mempty = memptyMdl
-  mappend = mappendMdl
+  mappend = (<>)
 
 memptyMdl :: forall r s f u v . ( Monoidal f r s, Function s
                                 , ObjectPair s u u, Monoid v


### PR DESCRIPTION
Build failed for me when building with base-4.11.1.0, I tracked the issue down to the fact that Semigroup became a superclass of Monoid in base 4.11.0.0, so I made the instances of Monoid in Data.Foldable.Constrained instances of Semigroup too.