### PR TITLE
Fixing MonadFail bug due to the change in ghc-8.8.1

### DIFF
--- a/Control/Category/Constrained/Prelude.hs
+++ b/Control/Category/Constrained/Prelude.hs
@@ -23,7 +23,7 @@ import Prelude hiding ( id, const, fst, snd, (.), ($), curry, uncurry
                       , Functor(..), (<$>), Applicative(..), (<*>), Monad(..), (=<<), filter
                       , mapM, mapM_, sequence, sequence_
                       , Foldable, foldMap, fold, traverse_, concatMap
-                      , Traversable, traverse )
+                      , Traversable, traverse, MonadFail(..) )
 
 import Control.Category.Constrained hiding (ConstrainedMorphism)
 import Control.Functor.Constrained

--- a/Control/Monad/Constrained.hs
+++ b/Control/Monad/Constrained.hs
@@ -43,7 +43,7 @@ import Data.Tagged
 
 import Prelude hiding (
      id, const, fst, snd, (.), ($)
-   , Functor(..), Applicative(..), Monad(..), (=<<)
+   , Functor(..), Applicative(..), Monad(..), MonadFail(..), (=<<)
    , uncurry, curry, filter
    , mapM, mapM_, sequence, sequence_
    )
@@ -131,7 +131,8 @@ instance (Hask.MonadPlus m, Hask.Applicative m) => MonadPlus m (->) where
 class (MonadPlus m k) => MonadFail m k where
   fail :: (Object k (m a)) => k String (m a) 
 
-instance (Hask.MonadPlus m, Hask.Applicative m) => MonadFail m (->) where
+instance (Hask.MonadPlus m, Hask.Applicative m, Hask.MonadFail m) 
+          => MonadFail m (->) where
   fail = Hask.fail
   
 

--- a/Control/Monad/Constrained.hs
+++ b/Control/Monad/Constrained.hs
@@ -48,6 +48,7 @@ import Prelude hiding (
    , mapM, mapM_, sequence, sequence_
    )
 import qualified Control.Category.Hask as Hask
+import qualified Control.Monad.Fail as HaskFail
 
 import Control.Arrow.Constrained
 
@@ -131,7 +132,7 @@ instance (Hask.MonadPlus m, Hask.Applicative m) => MonadPlus m (->) where
 class (MonadPlus m k) => MonadFail m k where
   fail :: (Object k (m a)) => k String (m a) 
 
-instance (Hask.MonadPlus m, Hask.Applicative m, Hask.MonadFail m) 
+instance (Hask.MonadPlus m, Hask.Applicative m, HaskFail.MonadFail m) 
           => MonadFail m (->) where
   fail = Hask.fail
   

--- a/constrained-categories.cabal
+++ b/constrained-categories.cabal
@@ -45,6 +45,7 @@ Library
                       , void
                       , semigroups
                       , contravariant
+                      , fail
                       , trivial-constraint >= 0.4 && < 0.5
   Default-Extensions: ConstraintKinds
                       TypeFamilies


### PR DESCRIPTION
Build failed with ghc version 8.10.1 
This was due to a change that took place in ghc 8.8.1 ([release note](https://downloads.haskell.org/~ghc/8.8.1/docs/html/users_guide/8.8.1-notes.html)).

I quickly fixed it so that everything builds again. Though I am not an expert so please be careful with this.