### PR TITLE
Add constraints to (&&&) and terminal

### DIFF
--- a/Control/Arrow/Constrained.hs
+++ b/Control/Arrow/Constrained.hs
@@ -128,12 +128,16 @@ class (CoCartesian a) => MorphChoice a where
 --   between /initial-/ and /terminal objects/. The latter are more interesting,
 --   basically what 'UnitObject' is useful for. It gives rise to the tuple
 --   selector morphisms as well.
-class (Morphism a) => PreArrow a where
-  (&&&) :: ( Object a b, ObjectPair a c c' )
+class (Morphism a, DuplicateObject a (UnitObject a), TerminateObject a (UnitObject a)) => PreArrow a where
+  type DuplicateObject a b :: Constraint
+  type DuplicateObject a b = ()
+  type TerminateObject a b :: Constraint
+  type TerminateObject a b = ()
+  (&&&) :: ( Object a b, ObjectPair a c c', DuplicateObject a b )
          => a b c -> a b c' -> a b (c,c')
-  terminal :: ( Object a b ) => a b (UnitObject a)
-  fst :: (ObjectPair a x y) => a (x,y) x
-  snd :: (ObjectPair a x y) => a (x,y) y
+  terminal :: ( Object a b, TerminateObject a b ) => a b (UnitObject a)
+  fst :: (ObjectPair a x y, TerminateObject a y) => a (x,y) x
+  snd :: (ObjectPair a x y, TerminateObject a x) => a (x,y) y
 
 infixr 2 |||
 -- | Dual to 'PreArrow', this class deals with the vacuous initial (zero) objects,
@@ -206,7 +210,7 @@ class (PreArrow a, ObjectPoint a (UnitObject a)) => WellPointed a where
   globalElement :: (ObjectPoint a x) => x -> a (UnitObject a) x
   globalElement = const
   unit :: CatTagged a (UnitObject a)
-  const :: (Object a b, ObjectPoint a x) 
+  const :: (Object a b, ObjectPoint a x, TerminateObject a b)
             => x -> a b x
   const x = globalElement x . terminal
 
@@ -336,6 +340,8 @@ instance (Morphism a, o (UnitObject a)) => Morphism (o⊢a) where
   ConstrainedMorphism a *** ConstrainedMorphism b = ConstrainedMorphism $ a *** b
   
 instance (PreArrow a, o (UnitObject a)) => PreArrow (o⊢a) where
+  type DuplicateObject (o⊢a) x = DuplicateObject a x
+  type TerminateObject (o⊢a) x = TerminateObject a x
   ConstrainedMorphism a &&& ConstrainedMorphism b = ConstrainedMorphism $ a &&& b
   terminal = ConstrainedMorphism terminal
   fst = ConstrainedMorphism fst
@@ -403,12 +409,13 @@ ifThenElse = arr $ \c -> arr $ \tv -> arr $ \fv -> if c then tv else fv
 
 
 genericAgentCombine :: ( HasAgent k, PreArrow k
-                       , Object k a, ObjectPair k b c, Object k d )
+                       , Object k a, ObjectPair k b c, Object k d
+                       , DuplicateObject k a)
      => k (b,c) d -> GenericAgent k a b -> GenericAgent k a c -> GenericAgent k a d
 genericAgentCombine m (GenericAgent v) (GenericAgent w)
        = GenericAgent $ m . (v &&& w)
   
-genericUnit :: ( PreArrow k, HasAgent k, Object k a )
+genericUnit :: ( PreArrow k, HasAgent k, Object k a, TerminateObject k a )
         => GenericAgent k a (UnitObject k)
 genericUnit = GenericAgent terminal
 
@@ -429,6 +436,7 @@ class (Morphism k, HasAgent k) => CartesianAgent k where
 
 genericAlg1to2 :: ( PreArrow k, u ~ UnitObject k
                   , Object k a, ObjectPair k b c
+                  , DuplicateObject k a
                   ) => ( forall q . Object k q
                       => GenericAgent k q a -> (GenericAgent k q b, GenericAgent k q c) )
                -> k a (b,c)
@@ -436,6 +444,8 @@ genericAlg1to2 f = runGenericAgent b &&& runGenericAgent c
  where (b,c) = f $ GenericAgent id
 genericAlg2to1 :: ( PreArrow k, u ~ UnitObject k
                   , ObjectPair k a u, ObjectPair k a b, ObjectPair k b u, ObjectPair k b a
+                  , TerminateObject k a
+                  , TerminateObject k b
                   ) => ( forall q . Object k q
                       => GenericAgent k q a -> GenericAgent k q b -> GenericAgent k q c )
                -> k (a,b) c
@@ -443,6 +453,10 @@ genericAlg2to1 f = runGenericAgent $ f (GenericAgent fst) (GenericAgent snd)
 genericAlg2to2 :: ( PreArrow k, u ~ UnitObject k
                   , ObjectPair k a u, ObjectPair k a b, ObjectPair k c d
                   , ObjectPair k b u, ObjectPair k b a
+                  --TODO: Can the duplicate and terminate be eliminated?
+                  , DuplicateObject k (a, b)
+                  , TerminateObject k a
+                  , TerminateObject k b
                   ) => ( forall q . Object k q
                       => GenericAgent k q a -> GenericAgent k q b 
                          -> (GenericAgent k q c, GenericAgent k q d) )
@@ -455,7 +469,7 @@ class (HasAgent k, AgentVal k a x ~ p a x)
            => PointAgent p k a x | p -> k where
   point :: (Object k a, Object k x) => x -> p a x
 
-genericPoint :: ( WellPointed k, Object k a, ObjectPoint k x )
+genericPoint :: ( WellPointed k, Object k a, ObjectPoint k x, TerminateObject k a )
        => x -> GenericAgent k a x
 genericPoint x = GenericAgent $ const x
 

--- a/Control/Monad/Constrained.hs
+++ b/Control/Monad/Constrained.hs
@@ -86,6 +86,7 @@ g >>= h = (=<<) h $ g
 infixr 1 <<
 (<<) :: ( Monad m k, WellPointed k
         , Object k a, Object k b, Object k (m a), ObjectPoint k (m b), Object k (m (m b))
+        , TerminateObject k a
         ) => m b -> k (m a) (m b)
 (<<) b = join . fmap (const b)
 
@@ -95,6 +96,7 @@ infixl 1 >>
         , ObjectPair k (UnitObject k) (m b), ObjectPair k b a
         , ObjectPair k a b, Object k (m (a,b)), ObjectPair k (m a) (m b)
         , ObjectPoint k (m a)
+        , TerminateObject k a
         ) => m a -> k (m b) (m b)
 (>>) a = fmap snd . fzip . first (globalElement a) . swap . attachUnit
   -- where result = arr $ \b -> (join . fmap (const b)) `inCategoryOf` result $ a
@@ -203,6 +205,8 @@ instance (Monad m a, Morphism a, Curry a) => Morphism (Kleisli m a) where
   second (Kleisli f) = Kleisli $ fzip . (pure *** f)
   Kleisli f *** Kleisli g = Kleisli $ fzip . (f *** g)
 instance (Monad m a, PreArrow a, Curry a) => PreArrow (Kleisli m a) where
+  type DuplicateObject (Kleisli m a) o = DuplicateObject a o
+  type TerminateObject (Kleisli m a) o = TerminateObject a o
   Kleisli f &&& Kleisli g = Kleisli $ fzip . (f &&& g)
   terminal = Kleisli $ pure . terminal
   fst = Kleisli $ pure . fst
@@ -255,11 +259,13 @@ guard = i . choose fmzero pure
 
 when :: ( Monad m k, PreArrow k, u ~ UnitObject k
         , ObjectPair k (m u) u
+        , TerminateObject k (m u)
         ) => Bool -> m u `k` m u
 when True = id
 when False = pure . terminal
 unless :: ( Monad m k, PreArrow k, u ~ UnitObject k
         , ObjectPair k (m u) u
+        , TerminateObject k (m u)
         ) => Bool -> m u `k` m u
 unless False = id
 unless True = pure . terminal
@@ -271,6 +277,9 @@ filterM :: ( PreArrow k, Monad m k, SumToProduct c k k, EndoTraversable c k
            , ObjectPair k (m Bool) (m a)
            , ObjectPair k (m (Bool, a)) (m (c (Bool, a)))
            , TraversalObject k c (Bool, a)
+           , TerminateObject k Bool --NOTE: This can probably be eliminated
+           , TerminateObject k a
+           , DuplicateObject k a
            ) => a `k` m Bool -> c a `k` m (c a)
 filterM pg = fmap (fmap snd <<< filter fst) <<< mapM (fzip <<< pg &&& pure)
     
@@ -278,6 +287,7 @@ filterM pg = fmap (fmap snd <<< filter fst) <<< mapM (fzip <<< pg &&& pure)
 
 forever :: ( Monad m k, Function k, Arrow k (->), Object k a, Object k b 
            , Object k (m a), Object k (m (m a)), ObjectPoint k (m b), Object k (m (m b))
+           , TerminateObject k a
            ) => m a `k` m b
 forever = i . arr loop 
     where loop a = (join . fmap (const $ loop a)) `inCategoryOf` i $ a
@@ -285,6 +295,7 @@ forever = i . arr loop
 
 void :: ( Monad m k, PreArrow k
         , Object k a, Object k (m a), ObjectPair k a u, u ~ UnitObject k 
+        , TerminateObject k a
         ) => m a `k` m (UnitObject k)
 void = fmap terminal
  

--- a/Data/Foldable/Constrained.hs
+++ b/Data/Foldable/Constrained.hs
@@ -142,6 +142,7 @@ traverse_ :: forall t k l o f a b uk ul .
            , ObjectPair k b ul, Object k (f b)
            , ObjectPair k (f ul) (f ul), ObjectPair k ul ul
            , uk ~ UnitObject k, ul ~ UnitObject l, uk ~ ul
+           , TerminateObject k b
            ) => a `k` f b -> t a `l` f ul
 traverse_ f = ffoldl q . first pureUnit . swap . attachUnit
     where q :: k (f uk, a) (f uk)
@@ -158,6 +159,7 @@ mapM_ :: forall t k o f a b u .
            , ObjectPair k u (t a), ObjectPair k (t a) u
            , ObjectPair k (f u) (f u), ObjectPair k u u
            , ObjectPair k b u, Object k (f b)
+           , TerminateObject k b
            ) => a `k` f b -> t a `k` f u
 mapM_ = traverse_
        
@@ -172,6 +174,7 @@ forM_ :: forall t k l f a b uk ul .
           , ObjectPair l (t a) ul, ObjectPair l (f ul) a
           , ObjectPair k b (f b), ObjectPair k b ul
           , ObjectPair k uk uk, ObjectPair k (f uk) a, ObjectPair k (f uk) (f uk)
+          , TerminateObject k b
           ) => t a -> a `k` f b -> f uk
 forM_ v f = traverse_ f $ v
 
@@ -185,6 +188,7 @@ sequence_ :: forall t k l m a b uk ul .
              , ObjectPair l (m ul) (t (m a)), ObjectPair l ul (t (m a))
              , ObjectPair l (m uk) (t (m a)), ObjectPair l (t (m a)) ul
              , ObjectPair k (m uk) (m a)
+             , TerminateObject k a
              ) => t (m a) `l` m uk
 sequence_ = traverse_ id 
 


### PR DESCRIPTION
This allows the author of a category to control which objects can be duplicated or destroyed

Feedback would be very welcome!  There were a few spots I had to fix up that I didn't really understand.